### PR TITLE
Fix for decreasing counters

### DIFF
--- a/tests/test_actual_data.py
+++ b/tests/test_actual_data.py
@@ -64,14 +64,14 @@ def test_erroneous_data2():
     up.insert(TimeTicks(1204345937, ROW_VALID, 677747340))
 
     bad_data = []
-    def callback(ancestor, agg, rate, prev, curr):
-        bad_data.append(rate)
+    def callback(message):
+        bad_data.append(message)
 
     var.update_all_aggregates(uptime_var=up, max_rate=int(11*1e9),
-            max_rate_callback=callback)
+            error_callback=callback)
 
     print bad_data
-    assert len(bad_data) == 0
+    assert len(bad_data) == 1
 
 @with_setup(db_reset, db_reset)
 def test_gaps1():
@@ -204,7 +204,7 @@ def test_bad_aggregation1():
                                  uptime_var=None,
                                  min_last_update=min_last_update,
                                  max_rate=int(110e9),
-                                 max_rate_callback=callback)
+                                 error_callback=callback)
 
     update(var, 1454514785, ROW_VALID, 63615634280445, update_agg=False)
     update(var, 1454514815, ROW_VALID, 63615634282858)
@@ -234,8 +234,8 @@ def test_bad_aggregation2():
     agg = var.add_aggregate("30s", YYYYMMDDChunkMapper, ['average', 'delta'])
 
     bad_data = []
-    def callback(ancestor, agg, rate, prev, curr):
-        bad_data.append(rate)
+    def callback(message):
+        bad_data.append(message)
 
     def update(var, ts, flags, value, update_agg=True):
         counter = Counter64(ts, flags, value)
@@ -255,7 +255,7 @@ def test_bad_aggregation2():
                                  uptime_var=None,
                                  min_last_update=min_last_update,
                                  max_rate=int(110e9),
-                                 max_rate_callback=callback)
+                                 error_callback=callback)
 
     update(var, 1501635150, ROW_VALID, 300290824551, update_agg=False)
     update(var, 1501635180, ROW_VALID, 300290824919)
@@ -264,7 +264,8 @@ def test_bad_aggregation2():
     update(var, 1501635270, ROW_VALID, 300290814799)
     update(var, 1501635305, ROW_VALID, 300290815063)
 
-    assert len(bad_data) == 0
+    assert len(bad_data) == 1
+    print bad_data
     for row in agg.select(begin=1501635150, end=1501635305):
         print row
 

--- a/tsdb/base.py
+++ b/tsdb/base.py
@@ -430,14 +430,14 @@ class TSDBVar(TSDBBase):
             return self
 
     def update_aggregate(self, name, uptime_var=None, min_last_update=0,
-            max_rate=None, max_rate_callback=None):
+            max_rate=None, error_callback=None):
         """Update the named aggreagate."""
         return Aggregator(self.get_aggregate(name),
                           self._get_aggregate_ancestor(name)
                          ).update(uptime_var=uptime_var,
                                   min_last_update=int(min_last_update),
                                   max_rate=max_rate,
-                                  max_rate_callback=max_rate_callback)
+                                  error_callback=error_callback)
 
     def update_all_aggregates(self, **kwargs):
         """Update all aggregates for this TSDBVar."""

--- a/tsdb/row.py
+++ b/tsdb/row.py
@@ -9,6 +9,7 @@ import struct
 ROW_VALID   = 0x0001  # does this row have valid data?
 ROW_WRAP    = 0x0002  # was there a wrap between this entry and the previous
 ROW_UNWRAP  = 0x0004  # the wrap for this entry was corrected
+ROW_INVALID = 0x0008  # this row should never be made valid
 
 class TSDBRow(object):
     """A TSDBRow represents a datapoint inside a TSDBVar.


### PR DESCRIPTION
This change makes it so that we no longer try to detect rollovers or restarts.
Instead we just invalidate data in the aggregate when we see a negative
counter delta.

This adds a new row flag called ROW_INVALID. This is used to ensure that a
partial update isn't applied to the trailing edge of the range where there
was a decreasing counter.

Fixes #2.